### PR TITLE
[User] 로그인 되지 않은 상태에서 비밀번호 재설정

### DIFF
--- a/app/handlers/email_handler.py
+++ b/app/handlers/email_handler.py
@@ -29,3 +29,33 @@ async def verify_email(
     token = authorization.replace("Bearer ", "")
     await email_service.verify_email_token(token)
     return ApiResponse(message="이메일 인증 완료")
+
+# 비밀번호 재설정 이메일 전송
+@router.post("/request-password-reset", response_model_exclude_none=True)
+async def request_password_reset(
+    email: str,
+    email_service: EmailService = Depends()
+)->ApiResponse[None]:
+    await email_service.request_password_reset(email)
+    return ApiResponse(message="비밀번호 재설정 메일 발송 완료")
+
+# 비밀번호 재설정
+@router.post("/reset-password", response_model_exclude_none=True)
+async def reset_password(
+    req: ResetPassword,
+    authorization: str = Header(...),
+    user_service: UserService = Depends()
+) -> ApiResponse[None]:
+    token = authorization.replace("Bearer ", "")
+    await user_service.reset_password(token, req.new_password)
+    return ApiResponse(message="비밀번호 재설정 완료")
+
+# 프론트에서 reset-password 페이지를 띄우기 전에 토큰 유효성 검사
+@router.post("/verify-password-reset-token", response_model_exclude_none=True)
+def verify_password_reset_token(authorization: str = Header(...)) -> ApiResponse[None]:
+    try:
+        token = authorization.replace("Bearer ", "")
+        JWTUtil.decode_password_reset_token(token)
+        return ApiResponse(message="토큰이 유효합니다.")
+    except Exception:
+        raise HTTPException(status_code=400, detail="토큰이 유효하지 않습니다.")

--- a/app/handlers/email_handler.py
+++ b/app/handlers/email_handler.py
@@ -1,26 +1,31 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Header
+from pydantic import BaseModel
 from sqlmodel import Session
 from app.db.session import get_db_session
 from app.schemas.common_schema import ApiResponse
 from app.core.redis import get_redis
 from redis.asyncio import Redis
+from app.schemas.user_schema import ResetPassword
 from app.services.email_service import EmailService
+from app.services.user_service import UserService
+from app.utils.jwt_util import JWTUtil
 
 router = APIRouter()
 
 @router.post("/request-verification-email", response_model_exclude_none=True)
 async def request_verification_email(
     email: str,
-    provider: str,
     email_service: EmailService = Depends()
 ) -> ApiResponse[None]:
-    await email_service.request_verification(email, provider)
+    await email_service.request_verification(email)
     return ApiResponse(message="인증 메일 발송 완료")
 
-@router.get("/verify-email", response_model_exclude_none=True)
+# 토큰 유효성 검사 + 이메일 인증 완료 처리
+@router.post("/verify-email-token", response_model_exclude_none=True)
 async def verify_email(
-    token: str,
+    authorization: str = Header(...),
     email_service: EmailService = Depends()
 ) -> ApiResponse[None]:
+    token = authorization.replace("Bearer ", "")
     await email_service.verify_email_token(token)
     return ApiResponse(message="이메일 인증 완료")

--- a/app/schemas/user_schema.py
+++ b/app/schemas/user_schema.py
@@ -42,3 +42,5 @@ class UserRead(BaseModel):
 
 UserReadResponse = ApiResponse[UserRead]
 
+class ResetPassword(BaseModel):
+    new_password: str

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -36,6 +36,14 @@ class EmailService:
         url = f"http://localhost:3000/verify-email?token={token}"
         self._send_email_for_verify(email, url)
 
+    async def request_password_reset(self, email: str):
+        user = self.db.exec(select(User).where(User.email == email)).first()
+        if not user:
+            raise HTTPException(status_code=400, detail="가입되지 않은 이메일 입니다.")
+        
+        token = JWTUtil.generate_password_reset_token(email)
+        url = f"http://localhost:3000/reset-password?token={token}"
+        self._send_email_for_reset(email, url)
 
     async def verify_email_token(self, token: str):
         try:
@@ -57,5 +65,17 @@ class EmailService:
             """
             self.smtp_client.send_email(to_email, subject, body)
     
+    def _send_email_for_reset(self, to_email: str, reset_url: str):
+        subject = "ResQ 비밀번호 재설정"
+        body = f"""
+        <html>
+            <body>
+                <h1>비밀번호 재설정</h1>
+                <p>아래 링크를 클릭하여 비밀번호를 재설정하세요.</p>
+                <a href="{reset_url}">비밀번호 재설정하기</a>
+            </body>
+        </html>
+        """
+        self.smtp_client.send_email(to_email, subject, body)
 
 

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -11,11 +11,7 @@ from app.utils.redis_util import mark_email_verified
 from redis.asyncio import Redis
 from app.core.redis import get_redis
 
-class BaseSMTPClient:
-    def send_email(self, to_email: str, subject: str, body: str):
-        raise NotImplementedError
-
-class GmailSMTPClient(BaseSMTPClient):
+class GmailSMTPClient:
     def send_email(self, to_email: str, subject: str, body: str):
         msg = MIMEText(body, "html", "utf-8")
         msg["Subject"] = Header(subject)
@@ -30,29 +26,25 @@ class EmailService:
     def __init__(self, db: Session=Depends(get_db_session), redis: Redis=Depends(get_redis)):
         self.db = db
         self.redis = redis
+        self.smtp_client = GmailSMTPClient()
     
-    async def request_verification(self, email: str, provider: str):
+    async def request_verification(self, email: str):
         if self.db.exec(select(User).where(User.email == email, User.status == UserStatus.ACTIVE)).first():
             raise HTTPException(status_code=400, detail="이미 가입된 이메일 입니다.")
         
         token = JWTUtil.generate_email_verification_token(email)
-        url = f"http://localhost:8000/api/verify-email?token={token}"
-        self._send_email(email, url, provider)
+        url = f"http://localhost:3000/verify-email?token={token}"
+        self._send_email_for_verify(email, url)
+
 
     async def verify_email_token(self, token: str):
         try:
             email = JWTUtil.decode_email_verification_token(token)
         except Exception:
             raise HTTPException(status_code=400, detail="예상하지 못한 오류")
-        await mark_email_verified(self.redis, email) 
+        await mark_email_verified(self.redis, email)
 
-    def _get_smtp_client(self, provider: str) -> BaseSMTPClient:
-        if provider == "google":
-            return GmailSMTPClient()
-        else:
-            raise ValueError("지원하지 않는 이메일 제공자입니다.")
-
-    def _send_email(self, to_email: str, verify_url: str, provider: str):
+    def _send_email_for_verify(self, to_email: str, verify_url: str):
             subject = "ResQ 이메일 인증"
             body = f"""
             <html>
@@ -63,7 +55,7 @@ class EmailService:
                 </body>
             </html>
             """
-            smtp_client = self._get_smtp_client(provider)
-            smtp_client.send_email(to_email, subject, body)
+            self.smtp_client.send_email(to_email, subject, body)
+    
 
 

--- a/app/utils/jwt_util.py
+++ b/app/utils/jwt_util.py
@@ -54,3 +54,19 @@ class JWTUtil:
         if not email:
             raise HTTPException(status_code=400, detail="토큰에 이메일 정보가 없습니다.")
         return email
+    
+    @staticmethod
+    def generate_password_reset_token(email: str) -> str:
+        payload = {
+            "sub": email,
+            "exp": datetime.utcnow() + timedelta(minutes=30)
+        }
+        return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    
+    @staticmethod
+    def decode_password_reset_token(token: str) -> str:
+        decoded = JWTUtil.decode_token(token)
+        email = decoded.get("sub")
+        if not email:
+            raise HTTPException(status_code=400, detail="토큰에 이메일 정보가 없습니다.")
+        return email


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) Close #14 

## 📝작업 내용

> 비밀번호 재설정 이메일 요청 및 검증 후 비밀번호 변경 (비로그인 상태) 구현
토큰 헤더 방식으로 요청 구조 변경, Google SMTP로 smtp client 고정
(자세한 변경된 방식은 API 명세서에)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9b78dba1-8e7a-4233-bb3a-6dc56c2c8500)
![image](https://github.com/user-attachments/assets/b2924965-055a-47ff-a0bb-a82902391876)

**주의사항**
테스트 할 때 프론트가 필요하기 때문에 대체 방법으로 이메일 링크 복사 후
쿼리에 있는 토큰 복사하고
`POST /verify-email-token`
`POST /verify-password-reset-token`
의 Authorization Header에 복붙해서 수동으로 요청하여 검증을 완료합니다

FastAPI SwaggerUI에서 헤더에 토큰 넣으면 잘 안돼서 저 두개만 Postman으로 테스트 하세용
로그인 토큰, 이메일 검증 토큰, 비번 재설정 토큰 전부 다른거라 로그인처럼 자물쇠(Authorizaiton 버튼) 안쓰게 했습니당


## 💬리뷰 요구사항(선택)