### PR TITLE
[NEWS] 뉴스 목록 조회 및 특정 뉴스 조회 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pip install openai
 pip install langchain
 pip install langchain-openai
 pip install firebase_admin
+pip install bs4
 ```
 
 ### .env file 
@@ -113,6 +114,8 @@ project-root/
 │   │   ├── region_model.py
 │   │   ├── shelter_model.py
 │   │   ├── sponsor_model.py
+│   │   ├── hospital_model.py
+│   │   ├── news_model.pyd
 │   │   └── user_model.py           
 │   ├── schemas/
 │   │   ├── chatbot_schema.py
@@ -127,6 +130,8 @@ project-root/
 │   │   ├── post_schema.py
 │   │   ├── shelter_schema.py
 │   │   ├── sponsor_schema.py
+│   │   ├── hospital_schema.py
+│   │   ├── news_schema.py
 │   │   └── user_schema.py          
 │   ├── services/
 │   │   ├── chatbot_service.py
@@ -143,6 +148,8 @@ project-root/
 │   │   ├── region_service.py
 │   │   ├── shelter_service.py
 │   │   ├── sponsor_service.py
+│   │   ├── hospital_service.py
+│   │   ├── news_service.py
 │   │   └── user_service.py   
 │   └── utils/
 │       ├── fcm_util.py

--- a/app/handlers/news_handler.py
+++ b/app/handlers/news_handler.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlmodel import Session
+from app.db.session import get_db_session
+from app.schemas.news_schemas import NewsRead, NewsDetail
+from app.services.news_service import NewsService
+
+router = APIRouter()
+
+@router.get("/news/", response_model=list[NewsRead])
+def list_news(query: str = Query(..., description="검색어는 필수입니다"), session: Session = Depends(get_db_session)):
+    service = NewsService(session)
+    try:
+        news_list = service.fetch_news_from_naver(query=query)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"뉴스 검색 실패: {e}")
+    return news_list
+
+@router.get("/news/{news_id}", response_model=NewsDetail)
+def read_news_detail(news_id: int, session: Session = Depends(get_db_session)):
+    service = NewsService(session)
+    try:
+        news = service.get_news_by_id(news_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="뉴스를 찾을 수 없습니다.")
+
+    full_text = service.fetch_full_text(news.naver_url)
+
+    # 크롤링 실패 → description + 링크로 대체
+    if full_text == "본문을 가져올 수 없습니다.":
+        fallback = service.fetch_description_from_api(news.title)
+        if fallback:
+            full_text = f"{fallback.strip()}\n\n[자세한 기사 보기] {news.naver_url}"
+
+    return {
+        **news.dict(),
+        "full_text": full_text
+    }
+

--- a/app/models/news_model.py
+++ b/app/models/news_model.py
@@ -1,0 +1,10 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+
+class News(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    origin_url: str
+    naver_url: str
+    pub_date: datetime

--- a/app/schemas/news_schemas.py
+++ b/app/schemas/news_schemas.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+# 목록용 스키마
+class NewsRead(BaseModel):
+    id: int
+    title: str
+    pub_date: datetime
+
+    class Config:
+        orm_mode = True
+
+# 상세용 스키마
+class NewsDetail(BaseModel):
+    id: int
+    title: str
+    origin_url: str
+    naver_url: str
+    pub_date: datetime
+    full_text: str
+
+    class Config:
+        orm_mode = True

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -1,0 +1,137 @@
+import os
+import requests
+from datetime import datetime
+from typing import List
+
+from bs4 import BeautifulSoup
+from sqlmodel import Session, select
+from app.models.news_model import News
+
+NAVER_CLIENT_ID = os.getenv("NAVER_CLIENT_ID")
+NAVER_CLIENT_SECRET = os.getenv("NAVER_CLIENT_SECRET")
+
+class NewsService:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def fetch_news_from_naver(self, query: str = "재난") -> List[News]:
+        """네이버 뉴스 검색 API를 통해 뉴스 가져오기 + 저장"""
+        url = "https://openapi.naver.com/v1/search/news.json"
+        headers = {
+            "X-Naver-Client-Id": NAVER_CLIENT_ID,
+            "X-Naver-Client-Secret": NAVER_CLIENT_SECRET
+        }
+        params = {
+            "query": query,
+            "display": 20,
+            "start": 1,
+            "sort": "date"
+        }
+
+        response = requests.get(url, headers=headers, params=params)
+        if response.status_code != 200:
+            print(f"[ERROR] 네이버 뉴스 API 요청 실패: {response.status_code}")
+            return []
+
+        data = response.json()
+        items = data.get("items", [])
+        added_news = []
+
+        for item in items:
+            title = self._strip_html(item["title"])
+            origin_url = item["originallink"]
+            naver_url = item["link"]
+            pub_date = self._parse_pubdate(item["pubDate"])
+
+            # 중복 확인
+            existing = self.session.exec(
+                select(News).where(
+                    News.title == title,
+                    News.pub_date == pub_date
+                )
+            ).first()
+            if existing:
+                continue
+
+            news = News(
+                title=title,
+                origin_url=origin_url,
+                naver_url=naver_url,
+                pub_date=pub_date
+            )
+            self.session.add(news)
+            self.session.commit()
+            self.session.refresh(news)
+            added_news.append(news)
+
+        return added_news
+
+    def get_news_list(self) -> List[News]:
+        """뉴스 목록 반환 (최신순)"""
+        return self.session.exec(
+            select(News).order_by(News.pub_date.desc())
+        ).all()
+
+    def get_news_by_id(self, news_id: int) -> News:
+        news = self.session.get(News, news_id)
+        if not news:
+            raise ValueError("News not found")
+        return news
+
+    def fetch_full_text(self, news_url: str) -> str:
+        """네이버 뉴스 실제 링크에서 본문 크롤링"""
+        headers = {"User-Agent": "Mozilla/5.0"}
+        try:
+            res = requests.get(news_url, headers=headers, timeout=5)
+            soup = BeautifulSoup(res.text, "html.parser")
+
+            # 우선순위대로 셀렉터 시도
+            possible_selectors = [
+                "div#dic_area",            # 대부분 기사 본문
+                "div.newsct_article",      # 일부 모바일 페이지
+                "div.article_body",        # 구버전
+            ]
+
+            for selector in possible_selectors:
+                article = soup.select_one(selector)
+                if article and article.text.strip():
+                    return article.get_text(separator="\n").strip()
+
+            return "본문을 가져올 수 없습니다."
+
+        except Exception as e:
+            return f"[크롤링 오류] {e}"
+
+
+    def _strip_html(self, text: str) -> str:
+        """네이버 API에서 오는 title의 <b>태그 제거용"""
+        return BeautifulSoup(text, "html.parser").get_text()
+
+    def _parse_pubdate(self, pubdate_str: str) -> datetime:
+        """네이버 pubDate 파싱"""
+        return datetime.strptime(pubdate_str, "%a, %d %b %Y %H:%M:%S %z")
+
+    def fetch_description_from_api(self, title: str) -> str:
+        """title로 다시 API 검색하여 description 가져옴"""
+        url = "https://openapi.naver.com/v1/search/news.json"
+        headers = {
+            "X-Naver-Client-Id": NAVER_CLIENT_ID,
+            "X-Naver-Client-Secret": NAVER_CLIENT_SECRET
+        }
+        params = {
+            "query": title,
+            "display": 10,
+            "sort": "date"
+        }
+
+        try:
+            response = requests.get(url, headers=headers, params=params, timeout=5)
+            data = response.json()
+            for item in data.get("items", []):
+                clean_title = self._strip_html(item["title"])
+                if clean_title == title:
+                    return self._strip_html(item.get("description", ""))
+        except Exception as e:
+            print(f"[WARN] fallback description 검색 실패: {e}")
+        
+        return None

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ from app.handlers import like_handler
 from app.handlers import chatbot_handler
 from app.handlers import hospital_handler
 from app.services.hospital_service import fetch_and_store_hospitals
+from app.handlers import news_handler
+
 app = FastAPI()
 scheduler = BackgroundScheduler()
 
@@ -36,6 +38,7 @@ app.include_router(notification_region_handler.router, prefix="/api", tags=["not
 app.include_router(notification_disastertype_handler.router, prefix="/api", tags=["notification_disastertype"])
 app.include_router(notification_handler.router, prefix="/api", tags=["notification"])
 app.include_router(sponsor_handler.router, prefix="/api", tags=["sponsor"])
+app.include_router(news_handler.router, prefix="/api", tags= ["news"])
 
 
 @scheduler.scheduled_job("interval", hours=1)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #54 

## 📝작업 내용

<img width="909" height="142" alt="image" src="https://github.com/user-attachments/assets/e8a7f50c-da52-4fd3-90d8-b47d647689d2" />


## 💬리뷰 요구사항(선택)

<img width="245" height="119" alt="image" src="https://github.com/user-attachments/assets/ca1d41b7-8107-44d1-acf0-1f92f8e2cc93" />

정렬 기준은 일단 이 둘중에 날짜 순으로 했고 검색어를 필수로 넣어야합니다. 프론트에서 재난 별로 선택할 수 있게 만들어서(화재, 태풍 등) 그거 선택한 대로 목록 나오게 하면 될듯? 그리고 크롤링을 하긴 했는데 간혹 안되는 게 있어서 안되는거는 API에서의 요약 글 + 링크가 나오도록 했습니다. (아래 사진 참고)

<img width="817" height="120" alt="image" src="https://github.com/user-attachments/assets/b1de3313-d91e-428e-802c-0003a2793bbe" />
